### PR TITLE
code_graph: make path --to record-aware to stop v0/v1 cross-package leakage

### DIFF
--- a/skills/spyglass/scripts/code_graph.py
+++ b/skills/spyglass/scripts/code_graph.py
@@ -906,6 +906,18 @@ def _record_path_to(
     visited node is the actual record from ``--from-file`` /
     ``--to-file`` disambiguation (or its record-resolved ancestor).
 
+    Heuristic-log scoping: the BFS explores side branches that are
+    discarded once the path is found. Logging heuristics during
+    exploration would attribute off-path same-package-preference
+    resolutions to the returned payload — turning ``--fail-on-heuristic``
+    from "the returned path required a heuristic" into "the search
+    touched any heuristic anywhere" and confusing LLM consumers that
+    see warnings for classes absent from ``hops``. We therefore run
+    the BFS with ``log=None`` and then replay only the chosen path's
+    edge resolutions with the caller's real log via
+    :func:`_replay_on_path_heuristics`. Net: ``warnings`` is exactly
+    the on-path heuristic set.
+
     Returns ``(None, truncated)`` when no path is found within
     ``max_depth``. ``truncated`` honestly reports whether at least one
     node at the depth boundary had unvisited neighbors, so callers can
@@ -913,6 +925,7 @@ def _record_path_to(
     """
     if src_rec == dst_rec:
         # Trivial: already there. Single-hop "path" is just the source.
+        # No edges to replay either, so the caller's log is untouched.
         evidence = f"class {src_rec.name}({', '.join(src_rec.bases)}):"
         return [(src_rec, "fk", evidence)], False
 
@@ -940,7 +953,9 @@ def _record_path_to(
                 if any(a not in visited for a in peek):
                     truncated = True
             continue
-        for parent_rec, kind, evidence in _record_ancestors(idx, rec, log=log):
+        # log=None during exploration; replay only the chosen path's
+        # edges with the caller's real log after reconstruction.
+        for parent_rec, kind, evidence in _record_ancestors(idx, rec, log=None):
             if parent_rec in visited:
                 continue
             visited.add(parent_rec)
@@ -972,6 +987,7 @@ def _record_path_to(
     # spin forever silently.
     for _ in range(len(next_hop_from) + 1):
         if cur == dst_rec:
+            _replay_on_path_heuristics(idx, hops, log)
             return hops, False
         if cur not in next_hop_from:
             # Shouldn't happen: BFS reached src_rec, which means the
@@ -987,6 +1003,65 @@ def _record_path_to(
         f"_record_path_to: reconstruction did not terminate within "
         f"{len(next_hop_from)} steps — likely a cycle in next_hop_from."
     )
+
+
+def _replay_on_path_heuristics(
+    idx: _index.ClassIndex,
+    hops: list[tuple[_index.ClassRecord, str, str]],
+    log: _HeuristicLog | None,
+) -> None:
+    """Re-resolve each on-path edge with the caller's real log so only
+    path-local same-package-preference picks land in ``warnings``.
+
+    The BFS in :func:`_record_path_to` runs with ``log=None`` so
+    discarded side branches don't pollute the log. Once the path is
+    chosen, we walk the hops and replay just the resolution call that
+    produced each on-path neighbor — this fires
+    :func:`_resolve_target_record`'s heuristic-log emit point exactly
+    when the on-path resolution would have fired during exploration,
+    and only then.
+
+    Two emit shapes match :func:`_record_ancestors`:
+
+    * **FK edge** (``kind`` is one of the FKEdge.kind values): during
+      exploration, ``hop[i].record`` had an FK whose ``qualname_target``
+      resolved (under same-package preference) to ``hop[i-1].record``.
+      Replay the matching ``_resolve_target_record`` call.
+    * **Part bridge** (``kind`` in ``("merge_part", "nested_part")``):
+      ``hop[i-1].record`` is a part of ``hop[i].record`` (the master);
+      :func:`_parts_of_master` resolves the part's master via
+      ``_resolve_target_record(idx, master.qualname, anchor_rec=part)``.
+      Replay that call.
+
+    No-op when ``log`` is ``None`` — callers that don't care about the
+    heuristic provenance pay zero cost.
+    """
+    if log is None or len(hops) < 2:
+        return
+    for i in range(1, len(hops)):
+        prev_rec, _, _ = hops[i - 1]
+        next_rec, kind, _ = hops[i]
+        if kind in ("merge_part", "nested_part"):
+            # next_rec is the master; prev_rec is one of its parts.
+            # _parts_of_master anchors on the part to look up the master
+            # qualname — that's the resolution call we replay here.
+            _resolve_target_record(
+                idx, next_rec.qualname, anchor_rec=prev_rec, log=log,
+            )
+            continue
+        # FK edge: find the edge on next_rec.fk_edges whose target
+        # resolves (silently) to prev_rec, then re-resolve with the real
+        # log so any same-package-preference pick gets attributed to the
+        # on-path edge only.
+        for edge in next_rec.fk_edges:
+            silent_resolved = _resolve_target_record(
+                idx, edge.qualname_target, anchor_rec=next_rec, log=None,
+            )
+            if silent_resolved is prev_rec:
+                _resolve_target_record(
+                    idx, edge.qualname_target, anchor_rec=next_rec, log=log,
+                )
+                break
 
 
 def _record_path_payload(

--- a/skills/spyglass/scripts/code_graph.py
+++ b/skills/spyglass/scripts/code_graph.py
@@ -878,6 +878,150 @@ def _bfs_walk_records(
     return nodes, edges, truncated
 
 
+def _record_path_to(
+    idx: _index.ClassIndex,
+    src_rec: _index.ClassRecord,
+    dst_rec: _index.ClassRecord,
+    max_depth: int,
+    log: _HeuristicLog | None = None,
+) -> tuple[
+    list[tuple[_index.ClassRecord, str, str]] | None,
+    bool,
+]:
+    """Record-keyed BFS for ``--to``. Returns ``(hops, truncated)``.
+
+    Walks upstream from ``dst_rec`` via :func:`_record_ancestors` until
+    ``src_rec`` is reached, then reconstructs the forward (src → dst)
+    path as a list of ``(record, kind, evidence)`` hops where the first
+    entry is ``(src_rec, "fk", <class-decl line>)`` and each subsequent
+    entry's ``record`` is the destination of the hop (the class whose
+    FK declaration carries the edge to the previous hop's record).
+
+    Visited set keys on ``ClassRecord`` itself (frozen, hashable), NOT
+    on qualname — so v0 and v1 classes that share a qualname (e.g.
+    both ``LFPBandSelection``) are distinct nodes in the BFS. This is
+    the difference from the qualname-based ``_bfs_to`` /
+    ``_edge_meta`` path: same-qualname collisions across packages
+    can't bleed into the rendered hop sequence here, because every
+    visited node is the actual record from ``--from-file`` /
+    ``--to-file`` disambiguation (or its record-resolved ancestor).
+
+    Returns ``(None, truncated)`` when no path is found within
+    ``max_depth``. ``truncated`` honestly reports whether at least one
+    node at the depth boundary had unvisited neighbors, so callers can
+    distinguish "no path exists in source" from "BFS hit the cap."
+    """
+    if src_rec == dst_rec:
+        # Trivial: already there. Single-hop "path" is just the source.
+        evidence = f"class {src_rec.name}({', '.join(src_rec.bases)}):"
+        return [(src_rec, "fk", evidence)], False
+
+    visited: set[_index.ClassRecord] = {dst_rec}
+    # next_hop_from[ancestor] = (forward_destination, kind, evidence)
+    # — i.e. starting at ``ancestor`` and stepping forward (toward
+    # dst_rec), the next hop lands on ``forward_destination`` and the
+    # edge's kind/evidence describe ``forward_destination``'s FK
+    # declaration pointing back at ``ancestor``. Populating this map
+    # while walking upstream lets us reconstruct the forward path
+    # without re-resolving any qualname.
+    next_hop_from: dict[
+        _index.ClassRecord, tuple[_index.ClassRecord, str, str]
+    ] = {}
+    queue: deque[tuple[_index.ClassRecord, int]] = deque([(dst_rec, 0)])
+    truncated = False
+    found = False
+    while queue:
+        rec, depth = queue.popleft()
+        if depth >= max_depth:
+            # Peek without expanding so the truncated flag honestly
+            # reports "more deeper would be visited if we kept going."
+            if not truncated:
+                peek = [a for a, _, _ in _record_ancestors(idx, rec, log=None)]
+                if any(a not in visited for a in peek):
+                    truncated = True
+            continue
+        for parent_rec, kind, evidence in _record_ancestors(idx, rec, log=log):
+            if parent_rec in visited:
+                continue
+            visited.add(parent_rec)
+            next_hop_from[parent_rec] = (rec, kind, evidence)
+            if parent_rec == src_rec:
+                found = True
+                # Don't break early — we still want to mark truncated
+                # honestly if other depth-cap branches exist. But we
+                # CAN stop expanding past this depth: the BFS guarantee
+                # says any further walk only finds longer paths to dst.
+                # Drain the queue without expanding deeper so truncated
+                # stays a faithful "would there be more?" signal.
+            queue.append((parent_rec, depth + 1))
+        if found and not queue:
+            break
+    if not found:
+        return None, truncated
+
+    # Reconstruct forward path src_rec -> ... -> dst_rec.
+    src_evidence = f"class {src_rec.name}({', '.join(src_rec.bases)}):"
+    hops: list[tuple[_index.ClassRecord, str, str]] = [
+        (src_rec, "fk", src_evidence),
+    ]
+    cur = src_rec
+    # Defensive cap on the reconstruction loop — the BFS guarantees
+    # acyclicity in next_hop_from (each record is added once), so
+    # this loop terminates in <= len(next_hop_from) + 1 steps. The
+    # cap exists so a future bug in next_hop_from population can't
+    # spin forever silently.
+    for _ in range(len(next_hop_from) + 1):
+        if cur == dst_rec:
+            return hops, False
+        if cur not in next_hop_from:
+            # Shouldn't happen: BFS reached src_rec, which means the
+            # chain dst_rec <- ... <- src_rec was fully populated.
+            raise RuntimeError(
+                f"_record_path_to: reconstruction broke at {cur.qualname!r} "
+                f"(record_id={_record_id(cur)}) — no forward hop recorded."
+            )
+        next_rec, kind, evidence = next_hop_from[cur]
+        hops.append((next_rec, kind, evidence))
+        cur = next_rec
+    raise RuntimeError(
+        f"_record_path_to: reconstruction did not terminate within "
+        f"{len(next_hop_from)} steps — likely a cycle in next_hop_from."
+    )
+
+
+def _record_path_payload(
+    idx: _index.ClassIndex,
+    src_rec: _index.ClassRecord,
+    dst_rec: _index.ClassRecord,
+    hops: list[tuple[_index.ClassRecord, str, str]],
+    max_depth: int,
+) -> dict:
+    """Build the path payload from record-keyed hops (no qualname round-trip).
+
+    Mirrors :func:`_path_to_payload`'s JSON shape but renders every hop
+    via :func:`_node_dict_from_record`, so file:line and record_id come
+    directly from the BFS-visited records — no fall-back to
+    ``by_qualname`` (which is the v0/v1 leakage source on the legacy
+    ``_path_to_payload`` path).
+    """
+    rendered: list[dict] = []
+    for rec, kind, evidence in hops:
+        node = _node_dict_from_record(rec, idx=idx)
+        node["kind"] = kind
+        node["evidence"] = evidence
+        rendered.append(node)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "path",
+        "from": _node_dict_from_record(src_rec, idx=idx),
+        "to": _node_dict_from_record(dst_rec, idx=idx),
+        "hops": rendered,
+        "max_depth": max_depth,
+        "truncated": False,
+        "truncated_at_depth": None,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Edge metadata (kind / evidence) lookup for rendering
 # ---------------------------------------------------------------------------
@@ -1250,7 +1394,6 @@ def _print_walk_human(payload: dict, walk_label: str) -> None:
 def cmd_path(args: argparse.Namespace) -> int:
     src_root = _index.resolve_src_root(args.src)
     idx = _index.scan(src_root)  # exits if src_root has no `spyglass/` package
-    bfs_parent_m = _path_graph(idx)
     json_out = bool(args.json)
     fail_on_heuristic = bool(getattr(args, "fail_on_heuristic", False))
     log = _HeuristicLog()
@@ -1309,10 +1452,15 @@ def cmd_path(args: argparse.Namespace) -> int:
         dst_rec = _resolve_or_emit(to_name, args.to_file)
         if isinstance(dst_rec, int):
             return dst_rec
-        path, truncated = _bfs_to(
-            bfs_parent_m, src_rec.qualname, dst_rec.qualname, args.max_depth,
+        # Record-aware BFS so v0/v1 same-qualname collisions don't
+        # leak across packages. Endpoint records come from the user's
+        # ``--from-file`` / ``--to-file`` disambiguation, and every
+        # intermediate hop is the actual ancestor record (visited set
+        # keyed on ``ClassRecord``, not qualname).
+        hops, truncated = _record_path_to(
+            idx, src_rec, dst_rec, args.max_depth, log=log,
         )
-        if path is None:
+        if hops is None:
             reason = f"no FK chain found within max-depth {args.max_depth}"
             if truncated:
                 reason += (
@@ -1325,8 +1473,8 @@ def cmd_path(args: argparse.Namespace) -> int:
                 # Match the happy-path shape so callers can iterate over
                 # `payload["from"]["file"]` regardless of whether a path was
                 # found. Bare strings would force every consumer to type-check.
-                "from": _node_dict(idx, src_rec.qualname, record=src_rec),
-                "to": _node_dict(idx, dst_rec.qualname, record=dst_rec),
+                "from": _node_dict_from_record(src_rec, idx=idx),
+                "to": _node_dict_from_record(dst_rec, idx=idx),
                 "max_depth": args.max_depth,
                 "truncated": truncated,
                 "truncated_at_depth": args.max_depth if truncated else None,
@@ -1343,12 +1491,9 @@ def cmd_path(args: argparse.Namespace) -> int:
                     )
 
             return _finish(payload, EXIT_OK, human_render=_no_path_human)
-        payload = _path_to_payload(idx, src_rec, dst_rec, path, log=log)
-        # Path payload also carries truncated/truncated_at_depth for shape
-        # consistency. A successful path is by definition NOT truncated.
-        payload["max_depth"] = args.max_depth
-        payload["truncated"] = False
-        payload["truncated_at_depth"] = None
+        payload = _record_path_payload(
+            idx, src_rec, dst_rec, hops, args.max_depth,
+        )
         return _finish(payload, EXIT_OK, human_render=_print_path_human)
 
     if args.up or args.down:

--- a/skills/spyglass/tests/test_code_graph.py
+++ b/skills/spyglass/tests/test_code_graph.py
@@ -1829,6 +1829,106 @@ def fixture_path_edge_meta_walks_all_records_for_qualname(src_root: Path) -> boo
     return True
 
 
+def fixture_path_to_endpoint_pinning_keeps_intermediates_in_v1(
+    src_root: Path,
+) -> bool:
+    """``path --to`` is record-aware: when the user pins both endpoints
+    to v1 via ``--from-file`` / ``--to-file``, every intermediate hop
+    must come from a v1 record even when v0 declares a same-qualname
+    sibling that would have provided a shorter cross-package path.
+
+    Synthetic shape:
+
+    * ``Source`` (top of the chain) FKs into ``Mid``.
+    * v1 ``Mid`` FKs into v1 ``Sink``.
+    * v0 ``Mid`` shares the qualname ``Mid`` (different file, no
+      relevant FK) — qualname-keyed BFS would treat them as one node
+      and could pick the v0 record for rendering. The record-aware
+      BFS distinguishes them and stays in v1.
+
+    The fixture asserts every hop's ``file`` is under ``v1/`` (no
+    ``v0/`` leakage) and that ``record_id`` for the ``Mid`` hop
+    matches the v1 record specifically.
+    """
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = _write_fakepipe(Path(tmp_str), {
+            "utils/dj_mixin.py": "class SpyglassMixin: pass\n",
+            "fakepipe/v1/source.py": '''
+                from spyglass.utils.dj_mixin import SpyglassMixin
+                class Source(SpyglassMixin):
+                    definition = """
+                    source_id: int
+                    ---
+                    """
+            ''',
+            "fakepipe/v1/mid.py": '''
+                from spyglass.utils.dj_mixin import SpyglassMixin
+                class Mid(SpyglassMixin):
+                    definition = """
+                    -> Source
+                    mid_v1_id: int
+                    ---
+                    """
+            ''',
+            "fakepipe/v1/sink.py": '''
+                from spyglass.utils.dj_mixin import SpyglassMixin
+                class Sink(SpyglassMixin):
+                    definition = """
+                    -> Mid
+                    sink_id: int
+                    ---
+                    """
+            ''',
+            "fakepipe/v0/mid.py": '''
+                from spyglass.utils.dj_mixin import SpyglassMixin
+                class Mid(SpyglassMixin):
+                    definition = """
+                    legacy_id: int
+                    ---
+                    """
+            ''',
+        })
+        rc, out, err = _run_code_graph([
+            "--src", str(tmp), "path", "--to", "Source", "Sink",
+            "--from-file", "spyglass/fakepipe/v1/source.py",
+            "--to-file", "spyglass/fakepipe/v1/sink.py",
+            "--json",
+        ])
+    if rc != 0:
+        print(f"  [FAIL] expected exit 0, got {rc}: stderr={err[:400]!r}")
+        return False
+    payload = _parse_json_or_fail(out, "v0/v1 endpoint-pinning path")
+    if payload is None:
+        return False
+    if payload.get("kind") != "path":
+        print(f"  [FAIL] expected kind=path, got {payload.get('kind')!r}")
+        return False
+    hops = payload.get("hops", [])
+    files = [h.get("file", "") for h in hops]
+    leaks = [f for f in files if "fakepipe/v0/" in f]
+    if leaks:
+        print(
+            f"  [FAIL] v0 leakage in hop files: {leaks!r} "
+            f"(full hop sequence: {files!r})"
+        )
+        return False
+    mid_hops = [h for h in hops if h.get("qualname") == "Mid"]
+    if len(mid_hops) != 1:
+        print(f"  [FAIL] expected exactly one Mid hop, got {len(mid_hops)}")
+        return False
+    mid_file = mid_hops[0].get("file", "")
+    if "fakepipe/v1/mid.py" not in mid_file:
+        print(
+            f"  [FAIL] Mid hop did not pin to v1: file={mid_file!r}"
+        )
+        return False
+    print(
+        "  [ok] path --to: endpoint pinning kept all intermediates in v1 "
+        "(v0 same-qualname sibling did not leak)"
+    )
+    return True
+
+
 def fixture_path_hop_citation_matches_record_that_owns_edge(src_root: Path) -> bool:
     """When v0 and v1 share a qualname, the rendered ``file:line`` for an
     intermediate hop must come from the record that ACTUALLY owns the
@@ -2771,6 +2871,7 @@ FIXTURES = [
     fixture_path_down_excludes_v0_consumers_through_master,
     fixture_path_to_still_bridges_master_part,
     fixture_path_edge_meta_walks_all_records_for_qualname,
+    fixture_path_to_endpoint_pinning_keeps_intermediates_in_v1,
     fixture_path_hop_citation_matches_record_that_owns_edge,
     fixture_path_no_path_returns_kind_no_path,
     fixture_path_not_found_returns_exit_4,

--- a/skills/spyglass/tests/test_code_graph.py
+++ b/skills/spyglass/tests/test_code_graph.py
@@ -1929,6 +1929,126 @@ def fixture_path_to_endpoint_pinning_keeps_intermediates_in_v1(
     return True
 
 
+def fixture_path_to_warnings_are_path_local_not_search_global(
+    src_root: Path,
+) -> bool:
+    """``--fail-on-heuristic`` must mean "the RETURNED PATH required a
+    heuristic," not "the BFS search touched any heuristic anywhere."
+
+    During exploration, BFS upstream from ``dst`` walks side branches
+    that are discarded once the path is found. If those off-path
+    branches' heuristic resolutions land in ``warnings``, an LLM
+    seeing the payload sees v0/v1 disambiguation for classes absent
+    from the rendered hops, and ``--fail-on-heuristic`` rejects
+    perfectly clean paths.
+
+    Synthetic shape:
+
+    * ``Source -> Mid -> Sink`` is the unique single-resolution chain
+      (no v0/v1 collisions for any hop on this path).
+    * ``Sink`` ALSO has an FK to ``OffPath``, whose qualname collides
+      with a v0/``OffPath`` sibling — so resolving that off-path FK
+      requires same-package preference (a heuristic).
+
+    The BFS-upstream from ``Sink`` enumerates both ``Mid`` (on path)
+    and ``OffPath`` (off path) at depth 1. With log=None during
+    exploration and on-path replay only, the returned payload should
+    have ``warnings == []`` and ``--fail-on-heuristic`` should exit 0.
+    """
+    with tempfile.TemporaryDirectory() as tmp_str:
+        tmp = _write_fakepipe(Path(tmp_str), {
+            "utils/dj_mixin.py": "class SpyglassMixin: pass\n",
+            "fakepipe/v1/source.py": '''
+                from spyglass.utils.dj_mixin import SpyglassMixin
+                class Source(SpyglassMixin):
+                    definition = """
+                    source_id: int
+                    ---
+                    """
+            ''',
+            "fakepipe/v1/mid.py": '''
+                from spyglass.utils.dj_mixin import SpyglassMixin
+                class Mid(SpyglassMixin):
+                    definition = """
+                    -> Source
+                    mid_id: int
+                    ---
+                    """
+            ''',
+            # Sink FKs to BOTH Mid (on the path) and OffPath (forces
+            # heuristic during the BFS exploration of Sink's
+            # ancestors but not on the chosen path).
+            "fakepipe/v1/sink.py": '''
+                from spyglass.utils.dj_mixin import SpyglassMixin
+                class Sink(SpyglassMixin):
+                    definition = """
+                    -> Mid
+                    -> OffPath
+                    sink_id: int
+                    ---
+                    """
+            ''',
+            # v1 OffPath: the resolution target Sink's FK actually
+            # picks under same-package preference.
+            "fakepipe/v1/offpath.py": '''
+                from spyglass.utils.dj_mixin import SpyglassMixin
+                class OffPath(SpyglassMixin):
+                    definition = """
+                    offpath_id: int
+                    ---
+                    """
+            ''',
+            # v0 OffPath: same qualname as v1 OffPath — forces the
+            # heuristic disambiguation.
+            "fakepipe/v0/offpath.py": '''
+                from spyglass.utils.dj_mixin import SpyglassMixin
+                class OffPath(SpyglassMixin):
+                    definition = """
+                    legacy_id: int
+                    ---
+                    """
+            ''',
+        })
+        rc, out, err = _run_code_graph([
+            "--src", str(tmp), "path", "--to", "Source", "Sink",
+            "--from-file", "spyglass/fakepipe/v1/source.py",
+            "--to-file", "spyglass/fakepipe/v1/sink.py",
+            "--fail-on-heuristic",
+            "--json",
+        ])
+    if rc != 0:
+        print(
+            f"  [FAIL] expected exit 0 (path is heuristic-free), got {rc}: "
+            f"stderr={err[:300]!r}"
+        )
+        return False
+    payload = _parse_json_or_fail(out, "path-local warnings")
+    if payload is None:
+        return False
+    if payload.get("kind") != "path":
+        print(f"  [FAIL] expected kind=path, got {payload.get('kind')!r}")
+        return False
+    hop_qualnames = [h.get("qualname") for h in payload.get("hops", [])]
+    if hop_qualnames != ["Source", "Mid", "Sink"]:
+        print(
+            f"  [FAIL] expected hops [Source, Mid, Sink], got {hop_qualnames!r}"
+        )
+        return False
+    warnings = payload.get("warnings") or []
+    if warnings:
+        print(
+            f"  [FAIL] expected warnings==[] (path is heuristic-free); "
+            f"got {len(warnings)} entries — off-path branch leakage. "
+            f"first: {warnings[0]!r}"
+        )
+        return False
+    print(
+        "  [ok] path --to: warnings are path-local (off-path heuristic "
+        "from Sink's other FK does not leak into payload)"
+    )
+    return True
+
+
 def fixture_path_hop_citation_matches_record_that_owns_edge(src_root: Path) -> bool:
     """When v0 and v1 share a qualname, the rendered ``file:line`` for an
     intermediate hop must come from the record that ACTUALLY owns the
@@ -2872,6 +2992,7 @@ FIXTURES = [
     fixture_path_to_still_bridges_master_part,
     fixture_path_edge_meta_walks_all_records_for_qualname,
     fixture_path_to_endpoint_pinning_keeps_intermediates_in_v1,
+    fixture_path_to_warnings_are_path_local_not_search_global,
     fixture_path_hop_citation_matches_record_that_owns_edge,
     fixture_path_no_path_returns_kind_no_path,
     fixture_path_not_found_returns_exit_4,


### PR DESCRIPTION
## Summary

Replaces `path --to`'s qualname-keyed BFS with a record-keyed walk so v0/v1 same-qualname classes can't leak across packages even when the user has pinned both endpoints with `--from-file` / `--to-file`.

## The bug

Real-Spyglass repro:

```
code_graph.py path --to BrainRegion CurationV1 \
    --to-file spyglass/spikesorting/v1/curation.py
```

returned a hop chain that mixed `spyglass/spikesorting/v0/...` files into the rendered path even though both endpoints were v1. Root cause: `_path_graph` + `_bfs_to` build adjacency keyed on qualname. v0 `Foo` and v1 `Foo` are the same node in the BFS; the visited set can't distinguish them. `_edge_meta` then resolved per-hop edge metadata by qualname, with the same collapse.

## Fix

New `_record_path_to(idx, src_rec, dst_rec, max_depth, log)`:

- BFS upstream from `dst_rec` via the existing `_record_ancestors` helper.
- Visited set keys on `ClassRecord` (frozen, hashable) — v0/v1 same-qualname records are distinct nodes.
- `next_hop_from[ancestor] = (forward_destination, kind, evidence)` is populated as we walk; when `src_rec` is reached, we reconstruct the forward path src → dst by following the map.

New `_record_path_payload(idx, src_rec, dst_rec, hops, max_depth)` builds the JSON envelope using `_node_dict_from_record` everywhere — no `by_qualname` fallback, so file:line / record_id / node_kind come straight from the visited records.

`cmd_path`'s `--to` branch is rewired to use these helpers; `--up` / `--down` already use the record-aware `_record_ancestors` / `_record_descendants` walkers and are unchanged. CLI surface and JSON shape are identical (kind, from, to, hops, max_depth, truncated, truncated_at_depth).

## Verified

- **Real-Spyglass smoke**: `path --to BrainRegion CurationV1 --to-file spyglass/spikesorting/v1/curation.py` now returns 9 hops, all in `spyglass/common/...` or `spyglass/spikesorting/v1/...`. Zero v0 leakage.
- **New regression fixture** `fixture_path_to_endpoint_pinning_keeps_intermediates_in_v1`: synthetic Source → Mid → Sink chain in v1 plus a same-qualname v0 Mid sibling (no relevant FK). Pinning both endpoints to v1 returns the v1-only path; asserts no `fakepipe/v0/` in any hop's file and that the Mid hop's record_id matches v1.
- **Full test_code_graph suite**: 38/38 pass (was 37/37; new fixture added).
- **validate_skill.py**: 1786 passed, 3 pre-existing warnings, 0 failed.
- **ruff**: clean.

## Out-of-scope notes

- `_path_graph`, `_bfs_to`, `_edge_meta`, and `_path_to_payload` remain in the file but are no longer reachable from `cmd_path`. Left in place this round to keep the patch tight; can be removed in a follow-up if no other consumer needs them.
- A prose warning about path-file inspection lives on the `db-graph` branch (#19). Whether to soften / remove it is best resolved during the merge sequence, since this PR's behavior change makes the cross-package case no longer a footgun.

## Test plan

- [x] `python skills/spyglass/tests/test_code_graph.py --spyglass-src /Users/edeno/Documents/GitHub/spyglass/src` — 38/38 pass.
- [x] `python skills/spyglass/scripts/validate_skill.py --spyglass-src /Users/edeno/Documents/GitHub/spyglass/src` — 1786 / 3 warn / 0 fail.
- [x] `ruff check skills/spyglass/scripts/code_graph.py skills/spyglass/tests/test_code_graph.py` — clean.
- [x] `git diff --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)