### PR TITLE
Batch B: key hygiene — runnable-snippet hardening + script-first guidance

### DIFF
--- a/docs/plans/reference-key-hygiene-impl-plan.md
+++ b/docs/plans/reference-key-hygiene-impl-plan.md
@@ -1,7 +1,7 @@
 # Implementation plan — reference key hygiene and validator coverage
 
 **Date:** 2026-04-28
-**Status:** In progress.
+**Status:** Batches A and B complete (PR #22 + this PR). Batches C / D / E deferred.
 **Scope:** Reduce wrong or missing key claims in `skills/spyglass/references/` by tightening reference-writing policy, adding targeted validator checks for key-bearing examples, and adding evals that punish confident key invention.
 
 This plan responds to a repeated review finding: many dangerous Spyglass mistakes are not missing imports or broken links. They are plausible, copyable key claims that look reasonable to an LLM but fail against source or the user's runtime database.
@@ -126,6 +126,17 @@ Working classification for Batch B:
 | Validator coverage | Existing validator catches many dict-field cases, but not all prose/blob cases | Implement only narrow C1-C3 checks after Batch B surfaces concrete examples. |
 
 Do not broaden this into a full schema catalog. The next useful unit is a small PR that finishes the active `destructive_operations.md` parameter-blob correction, then audits one high-risk reference at a time.
+
+### Progress log
+
+- **2026-04-28 — PR #22 (merged, commit `66d1a34`):** Batch A audit + early Batch B. Fixed two concrete wrong/copyable findings: `RippleParameters` blob shape in `destructive_operations.md` and tutorial-specific `trodes_pos_params_name` hardcode in `mua_pipeline.md`. Round-2/3 follow-ups added scoped `RippleTimesV1.populate` key, multi-row ImportedPose discovery, BurstPair populate scope, v0 legacy `fetch_nwb()[0]` cardinality, and `behavior_pipeline.md` first-row pattern.
+- **2026-04-28 — Batch B narrow first pass (this PR):** focused pass over runnable code blocks in priority files (merge_methods, spyglassmixin_methods, datajoint_api, runtime_debugging, workflows, dependencies, feedback_loops, custom_pipeline_authoring). Added cardinality guards before `fetch_nwb`, replaced `assert` with explicit `if/raise ValueError` patterns, sharpened merge-master silent-no-op wording, fixed `LFPElectrodeGroup` join key in workflows, renamed shadowing `ElectrodeGroup` part class. Companion thread: promote `code_graph.py` / `db_graph.py` CLIs as the LLM-facing fact-check authority, with in-session DataJoint API as fallback (SKILL.md, common_mistakes.md, common_tables.md, datajoint_api.md, spyglassmixin_methods.md, workflows.md). SKILL.md L40 clarifies that bare CLI names mean `python skills/spyglass/scripts/<name>`. Stricter `_one()` helper in `spikesorting_v1_pipeline.md` raises on multi-row selection results instead of silently picking the first.
+
+### Remaining work
+
+- **Batch C narrow validator additions** — extend the dict-restriction field checker to `populate({...})` calls; add a singular/plural near-miss check (`_param_name` vs `_params_name`); add regression fixtures.
+- **Batch D evals** — pin the patterns this PR fixed (key invention, partial populate, blob shape, merge-master wrong restriction) so future regressions fail evals before they fail users.
+- **Batch E maintainer checklist** — open only if drift continues recurring after C/D land.
 
 ## Batch B — reference cleanup
 

--- a/skills/spyglass/SKILL.md
+++ b/skills/spyglass/SKILL.md
@@ -37,6 +37,8 @@ Router + guardrails for Spyglass work. Pick the right reference from the table b
 
 Treat table, key, attribute, method, dependency, parameter, and row-state claims as evidence-backed. Static/source facts: `code_graph.py`, source, or `inspect.signature`. Runtime facts: `db_graph.py`, `Table.heading`, counts, or fetches. Blob parameter keys need source `make()`/builders, docs, or actual rows. If unavailable, mark as hypothesis or abstain.
 
+Bare `code_graph.py` / `db_graph.py` means `python skills/spyglass/scripts/<name>`.
+
 ## Common Mistakes
 
 Top 6 highest-frequency bugs. Flag any of these shapes before answering. Expanded prose + three additional footguns: [common_mistakes.md](references/common_mistakes.md).

--- a/skills/spyglass/SKILL.md
+++ b/skills/spyglass/SKILL.md
@@ -35,9 +35,9 @@ Router + guardrails for Spyglass work. Pick the right reference from the table b
 
 ## Evidence Expectations
 
-Treat table, key, attribute, method, dependency, parameter, and row-state claims as evidence-backed. Static/source facts: `code_graph.py`, source, or `inspect.signature`. Runtime facts: `db_graph.py`, `Table.heading`, counts, or fetches. Blob parameter keys need source `make()`/builders, docs, or actual rows. If unavailable, mark as hypothesis or abstain.
+Treat table, key, attribute, method, dependency, parameter, and row-state claims as evidence-backed. Static/source facts: `code_graph.py`, source, or `inspect.signature`. Runtime facts: `db_graph.py`, `Table.heading`, counts, or fetches. Blob keys need source `make()`/builders, docs, or rows. If unavailable, abstain or flag uncertainty.
 
-Bare `code_graph.py` / `db_graph.py` means `python skills/spyglass/scripts/<name>`.
+`code_graph.py`/`db_graph.py` means `python skills/spyglass/scripts/<name>`.
 
 ## Common Mistakes
 

--- a/skills/spyglass/references/common_mistakes.md
+++ b/skills/spyglass/references/common_mistakes.md
@@ -68,7 +68,12 @@ No universal `target_interval_list_name` exists. The field varies by pipeline:
 
 A restriction that works on one selection table can silently match zero rows on another because the field name, the interval-name value, or both differ. DataJoint does not warn when a restriction field is missing from the table — the field is silently ignored.
 
-**Fix.** Inspect the downstream table's primary key (`Table.heading.primary_key`) to see the actual interval-field name. Confirm the value exists for the session with `(IntervalList & {"nwb_file_name": f}).fetch("interval_list_name")`. If the selection was inserted against a different interval than the one you're now restricting, re-insert with the correct value. Full triage including diagnostic queries and the two-interval decoding case: [runtime_debugging.md](runtime_debugging.md) Signature F.
+**Fix.** Inspect the downstream table's primary key (`db_graph.py describe`
+for runtime truth, `code_graph.py describe` for source truth, or
+`Table.heading.primary_key` inside the user's session) to see the actual
+interval-field name. Confirm the value exists for the session with
+`db_graph.py find-instance` or `(IntervalList & {"nwb_file_name": f}).fetch("interval_list_name")`.
+If the selection was inserted against a different interval than the one you're now restricting, re-insert with the correct value. Full triage including diagnostic queries and the two-interval decoding case: [runtime_debugging.md](runtime_debugging.md) Signature F.
 
 ## 7. Fragmenting lab-wide search with inconsistent names
 
@@ -162,4 +167,4 @@ recording_id = (SpikeSortingSelection & {'sorting_id': sid}).fetch1('recording_i
 
 Both fixes are correct. Fix 1 stays composable in one expression; Fix 2 is more legible when you want to pause and inspect `recording_id` mid-debug.
 
-**Diagnostic habit.** Before recommending a multi-table `*` chain, inspect each side's secondary attributes: `Table.heading.secondary_attributes`. Look for collisions — if any attribute appears in both, you need `.proj()` or a split. The Spyglass attributes most likely to collide are `nwb_file_name` (propagated via `-> Raw`, `-> Session`, `-> IntervalList`, `-> AnalysisNwbfile`, `-> Electrode`) and `interval_list_name` (via `-> IntervalList` on any selection table). When you're unsure, build the join one step at a time and inspect `.heading` after each `*`.
+**Diagnostic habit.** Before recommending a multi-table `*` chain, inspect each side's secondary attributes: use `db_graph.py describe` for runtime headings, `code_graph.py describe` for source headings, or `Table.heading.secondary_attributes` inside the user's session. Look for collisions — if any attribute appears in both, you need `.proj()` or a split. The Spyglass attributes most likely to collide are `nwb_file_name` (propagated via `-> Raw`, `-> Session`, `-> IntervalList`, `-> AnalysisNwbfile`, `-> Electrode`) and `interval_list_name` (via `-> IntervalList` on any selection table). When you're unsure, build the join one step at a time and inspect `.heading` after each `*`.

--- a/skills/spyglass/references/common_tables.md
+++ b/skills/spyglass/references/common_tables.md
@@ -16,7 +16,11 @@
 
 Tables in the `spyglass.common` schema. These are the root tables all pipelines depend on.
 
-**Important**: Always verify table structure with `Table.describe()` or `Table.heading` before writing queries that depend on specific column names. This reference provides an overview of table purposes and relationships, not an exhaustive schema copy.
+**Important**: Always verify table structure before writing queries that
+depend on specific column names. Use `code_graph.py describe` for
+source-declared structure, `db_graph.py describe` for the connected
+database, or `Table.describe()` / `Table.heading` inside the user's Python
+session. This reference is an overview, not an exhaustive schema copy.
 
 **Adjacent concepts.** Group tables (`SortedSpikesGroup`, `PositionGroup`, `UnitSelectionParams`) live in pipeline-specific schemas, not in `common`, but the shape recurs across pipelines — see [group_tables.md](group_tables.md). Merge tables similarly live in pipeline schemas — see [merge_methods.md](merge_methods.md).
 
@@ -229,7 +233,12 @@ Nwbfile
 
 ## Discovery Patterns
 
-When you need exact column names or key structure, always check the table directly:
+When you need exact column names or key structure, use the bundled scripts
+first when answering outside the user's live notebook: `code_graph.py
+describe <Class> --json` for source-declared keys/FKs, or `db_graph.py
+describe <Class> --count --json` for the connected database's runtime
+heading and row count. Inside a Python session, the equivalent direct
+DataJoint checks are:
 
 ```python
 # View full schema definition

--- a/skills/spyglass/references/custom_pipeline_authoring.md
+++ b/skills/spyglass/references/custom_pipeline_authoring.md
@@ -258,7 +258,7 @@ class MyElectrodeGroupSet(SpyglassMixin, dj.Manual):
     -> Session
     """
 
-    class ElectrodeGroup(SpyglassMixinPart):
+    class ElectrodeGroupMember(SpyglassMixinPart):
         """One row per `ElectrodeGroup` included in the set."""
 
         definition = """

--- a/skills/spyglass/references/datajoint_api.md
+++ b/skills/spyglass/references/datajoint_api.md
@@ -221,15 +221,23 @@ class MyComputedTable(SpyglassMixin, dj.Computed):
 
 ## Spyglass-Specific Operators
 
+These graph-search helpers are useful for interactive exploration. They are
+not the preferred way to build production keys for merge masters: for
+`PositionOutput`, `LFPOutput`, `SpikeSortingOutput`, `DecodingOutput`, etc.,
+prefer `merge_restrict(...)` / `merge_get_part(...)` when the next step is
+`fetch1`, `populate`, deletion, or generated code.
+
 ### Upstream Restriction (`<<`)
 
 Restrict by ancestor attribute — searches **up** the dependency chain. Use when the field you want to filter on belongs to a table upstream of the current table.
 
 ```python
-# Find all PositionOutput entries for a specific session
+# Exploratory: find all PositionOutput entries for a specific session.
+# For copyable merge-table code, prefer PositionOutput.merge_restrict(...).
 PositionOutput() << "nwb_file_name = 'j1620210710_.nwb'"
 
-# Find all SpikeSortingOutput entries for a subject
+# Exploratory: find all SpikeSortingOutput entries for a subject.
+# For copyable merge-table code, prefer SpikeSortingOutput.merge_restrict(...).
 SpikeSortingOutput() << "subject_id = 'J16'"
 ```
 
@@ -255,7 +263,7 @@ Session() >> 'decoding_param_name LIKE "contfrag_clusterless%"'
 Same as `<<`/`>>` but with explicit direction parameter.
 
 ```python
-# Upstream (equivalent to <<)
+# Upstream (equivalent to <<; exploratory on merge masters)
 PositionOutput().restrict_by(
     "nwb_file_name = 'j1620210710_.nwb'",
     direction="up"
@@ -311,8 +319,13 @@ Inherited via `SpyglassMixin` (from `FetchMixin`), but only resolves on **NWB-ba
 **Exception — decoding tables.** `ClusterlessDecodingV1` (and the SortedSpikes decoding equivalents) store results as xarray netCDF (`.nc`) + a pickled classifier, not NWB. They expose dedicated `fetch_results()` / `fetch_model()` / `fetch_environments()` methods instead of `fetch_nwb()`. See `decoding/v1/clusterless.py:99` (results_path declaration) and the `fetch_results` method nearby.
 
 ```python
-# Fetch NWB objects for a table entry (NWB-backed: LFPV1, TrodesPosV1, Raw, ...)
-nwb_objs = (LFPV1 & key).fetch_nwb()
+# Fetch NWB objects for a table entry (NWB-backed: LFPV1, TrodesPosV1, Raw, ...).
+# `fetch_nwb()` returns a list and does not enforce one-row cardinality.
+rel = LFPV1 & key
+n_rows = len(rel)
+if n_rows != 1:
+    raise ValueError(f"key matched {n_rows} rows; tighten before fetch_nwb")
+nwb_objs = rel.fetch_nwb()
 
 # Access data from NWB object
 lfp_data = nwb_objs[0]['lfp']

--- a/skills/spyglass/references/datajoint_api.md
+++ b/skills/spyglass/references/datajoint_api.md
@@ -278,6 +278,12 @@ Session().restrict_by(
 
 ## Table Inspection Commands
 
+For LLM answers, prefer the bundled scripts when they can answer the
+question: `code_graph.py describe/path/find-method` for source facts, and
+`db_graph.py describe/find-instance/path` for runtime headings, counts,
+rows, and DB adjacency. Use the interactive DataJoint forms below inside
+the user's Python session or when a script cannot see the needed context.
+
 ```python
 # View schema definition with primary/foreign keys
 Table.describe()
@@ -362,7 +368,7 @@ pose_df = (PositionOutput & merge_key).fetch_pose_dataframe()
 ## Best Practices
 
 1. **Always limit large queries**: Use `limit=` to avoid memory issues
-2. **Use friendly keys first**: Start with `nwb_file_name`, then get `merge_id`
+2. **Use evidence before code**: For source facts, run `code_graph.py`; for runtime headings, row counts, merge IDs, or custom tables, run `db_graph.py`
 3. **Preview before fetching**: Use `.fetch(limit=1)` or `.merge_view()` to check structure
 4. **Check table relationships**: Use `.describe()`, `.parents()`, `.children()` when joining
 5. **Prefer DataJoint over SQL**: Use restriction operators instead of raw SQL queries

--- a/skills/spyglass/references/datajoint_api.md
+++ b/skills/spyglass/references/datajoint_api.md
@@ -368,7 +368,7 @@ pose_df = (PositionOutput & merge_key).fetch_pose_dataframe()
 ## Best Practices
 
 1. **Always limit large queries**: Use `limit=` to avoid memory issues
-2. **Use evidence before code**: For source facts, run `code_graph.py`; for runtime headings, row counts, merge IDs, or custom tables, run `db_graph.py`
+2. **Use evidence before code**: For source facts, run `code_graph.py`; for runtime headings, row counts, merge IDs, or custom tables, run `db_graph.py`. For merge discovery, start with friendly keys like `nwb_file_name`, then resolve candidate `merge_id` values with merge-aware helpers.
 3. **Preview before fetching**: Use `.fetch(limit=1)` or `.merge_view()` to check structure
 4. **Check table relationships**: Use `.describe()`, `.parents()`, `.children()` when joining
 5. **Prefer DataJoint over SQL**: Use restriction operators instead of raw SQL queries

--- a/skills/spyglass/references/dependencies.md
+++ b/skills/spyglass/references/dependencies.md
@@ -22,8 +22,13 @@ Most raw and analysis data is stored in NWB files (HDF5-based) — tables refere
 **Exception — decoding output is not NWB.** `ClusterlessDecodingV1` and the SortedSpikes decoding equivalents store results as `xarray` netCDF (`.nc`) at a `filepath@analysis` external store, with the classifier pickled alongside (`.pkl`). They expose dedicated fetchers: `fetch_results()` (`xr.Dataset`) at `decoding/v1/clusterless.py:453`, `fetch_model()` at `:470`, `fetch_environments()` at `:475` — not `fetch_nwb()`. The storage declaration is at `decoding/v1/clusterless.py:99` (`results_path: filepath@analysis`).
 
 ```python
-# Fetch NWB objects from an NWB-backed table (e.g. LFPV1, TrodesPosV1, Raw)
-nwb_data = (Table & key).fetch_nwb()
+# Fetch NWB objects from an NWB-backed table (e.g. LFPV1, TrodesPosV1, Raw).
+# `fetch_nwb()` returns a list and does not enforce one-row cardinality.
+rel = Table & key
+n_rows = len(rel)
+if n_rows != 1:
+    raise ValueError(f"key matched {n_rows} rows; tighten before fetch_nwb")
+nwb_data = rel.fetch_nwb()
 
 # Access data from NWB object
 lfp_series = nwb_data[0]['lfp']

--- a/skills/spyglass/references/feedback_loops.md
+++ b/skills/spyglass/references/feedback_loops.md
@@ -114,7 +114,10 @@ After a pipeline `populate()`, confirm rows landed and one output has the expect
 ```python
 MyPipelineV1.populate(key)
 print(len(MyPipelineV1 & key))                   # keys you asked for get processed?
-sample = (MyPipelineV1 & key).fetch(limit=1, as_dict=True)[0]
+rows = (MyPipelineV1 & key).fetch(limit=1, as_dict=True)
+if not rows:
+    raise ValueError("populate produced no matching rows; debug this key before continuing")
+sample = rows[0]
 # Eyeball dtypes/shapes against downstream code's assumptions
 ```
 

--- a/skills/spyglass/references/merge_methods.md
+++ b/skills/spyglass/references/merge_methods.md
@@ -220,12 +220,12 @@ PositionOutput.merge_restrict({'nwb_file_name': nwb_file})
 # Chain further restrictions
 PositionOutput.merge_restrict({'nwb_file_name': nwb_file}) & 'source = "TrodesPosV1"'
 ```
-
 **Do not restrict the merge master directly with upstream keys for
 data access.** The master's only primary-key column is `merge_id`;
 fields like `nwb_file_name` live on the part tables. A query like
-`(LFPOutput & {'nwb_file_name': f}).fetch()` returns no usable rows.
-Use `merge_get_part`, `merge_restrict`, or `merge_fetch` instead:
+`(LFPOutput & {'nwb_file_name': f}).fetch()` silently ignores the
+session restriction and returns unrestricted master rows. Use
+`merge_get_part`, `merge_restrict`, or `merge_fetch` instead:
 
 ```python
 # Find all merge rows for a session, with part-table columns:

--- a/skills/spyglass/references/runtime_debugging.md
+++ b/skills/spyglass/references/runtime_debugging.md
@@ -305,7 +305,17 @@ one_param = (TrodesPosParams & {"trodes_pos_params_name": "default"}).fetch1("KE
 
 Or aggregate before joining with `.aggr()` if you truly want a many-to-one rollup.
 
-**Robust fix.** In `make()`, assert cardinality before fetching: `assert len(rel) == 1, f"{rel.primary_key} matched {len(rel)} rows for key={key}"`. This catches multiplicity at the earliest possible point rather than at a confusing `fetch1()` further down.
+**Robust fix.** In `make()`, check cardinality before fetching:
+
+```python
+n_rows = len(rel)
+if n_rows != 1:
+    raise ValueError(
+        f"{rel.heading.primary_key} matched {n_rows} rows for key={key}"
+    )
+```
+
+This catches multiplicity at the earliest possible point rather than at a confusing `fetch1()` further down.
 
 **Watch-outs.** Restricting a merge table with a friendly key (e.g., `{"nwb_file_name": ...}`) almost always multiplies — use `merge_get_part()` or `merge_restrict()` instead. See [merge_methods.md](merge_methods.md).
 
@@ -367,12 +377,9 @@ table's connection). Each schema has its own `~jobs` table:
 ```python
 import datajoint as dj
 
-# Pick the schema that owns the table you're populating.
-# `MyTable.database` is the underlying schema name; use that
-# instead of guessing.
-schema_name = MyTable.connection.dependencies.parent_class[
-    MyTable.full_table_name
-].database  # or just MyTable.database in many DataJoint versions
+# Pick the schema that owns the table you're populating. `MyTable.database`
+# is the underlying schema name; use it instead of guessing.
+schema_name = MyTable.database
 jobs = dj.Schema(schema_name).jobs
 
 # Filter to this table's failed entries before doing anything:

--- a/skills/spyglass/references/spyglassmixin_methods.md
+++ b/skills/spyglass/references/spyglassmixin_methods.md
@@ -163,7 +163,11 @@ View all columns as a heading object.
 ### `parents()` / `children()`
 View parent/child table relationships.
 
-For full transitive walks (every downstream consumer, every upstream prerequisite), use DataJoint's `descendants()` / `ancestors()` — defined on `dj.Table` and inherited by every `SpyglassMixin`. See [datajoint_api.md § Table Inspection Commands](datajoint_api.md#table-inspection-commands) for the full topology-commands block.
+For LLM-facing answers, prefer `code_graph.py path` for source-declared
+dependency walks and `db_graph.py path` for runtime DB walks. Inside the
+user's Python session, DataJoint's `descendants()` / `ancestors()` are the
+direct equivalents — defined on `dj.Table` and inherited by every
+`SpyglassMixin`. See [datajoint_api.md § Table Inspection Commands](datajoint_api.md#table-inspection-commands) for the full topology-commands block.
 
 ## Storage
 

--- a/skills/spyglass/references/spyglassmixin_methods.md
+++ b/skills/spyglass/references/spyglassmixin_methods.md
@@ -49,7 +49,8 @@ pynapple_obj = (Table & key).fetch_pynapple()
 Restrict table by searching up or down the dependency chain for matching fields.
 
 ```python
-# Find position outputs for a session (searches up for nwb_file_name)
+# Exploratory: find position outputs for a session by graph search.
+# For copyable merge-table code, prefer PositionOutput.merge_restrict(...).
 PositionOutput().restrict_by("nwb_file_name = 'file.nwb'", direction="up")
 
 # Find sessions with specific params (searches down)
@@ -60,6 +61,8 @@ Session().restrict_by('trodes_pos_params_name="default"', direction="down")
 Shorthand for `restrict_by(restriction, direction="up")`.
 
 ```python
+# Exploratory on merge masters; prefer PositionOutput.merge_restrict(...)
+# when building a key for fetch/populate/delete.
 PositionOutput() << "nwb_file_name = 'file.nwb'"
 ```
 

--- a/skills/spyglass/references/workflows.md
+++ b/skills/spyglass/references/workflows.md
@@ -195,12 +195,21 @@ Reach for these before writing a for-loop over intervals. They're correct at the
 
 ### No Results Found
 
+For an LLM-facing answer, prefer `db_graph.py find-instance` / `describe`
+for row counts and runtime headings, because the JSON output is easier to
+quote and distinguishes runtime DB facts from source facts. The Python
+checks below are the notebook-session fallback.
+
 ```python
 # Check session exists
-assert len(Session & {'nwb_file_name': nwb_file}) > 0, "Session not found"
+session_count = len(Session & {'nwb_file_name': nwb_file})
+if session_count == 0:
+    raise ValueError("Session not found")
 
 # Check interval exists
-assert len(IntervalList & key) > 0, "Interval not found"
+interval_count = len(IntervalList & key)
+if interval_count == 0:
+    raise ValueError("Interval not found")
 
 # Preview merge table scoped to this session.
 # Don't call merge_view() without a restriction — it prints the entire
@@ -221,6 +230,12 @@ for part in parts:
 ```
 
 ### Join Not Working
+
+For source-declared relationships, run `code_graph.py path` or
+`code_graph.py describe` first. For relationships in the connected
+database, especially custom tables or schema drift, run `db_graph.py path`
+or `db_graph.py describe`. The direct DataJoint checks below are the
+notebook-session fallback.
 
 ```python
 # Inspect keys

--- a/skills/spyglass/references/workflows.md
+++ b/skills/spyglass/references/workflows.md
@@ -68,21 +68,37 @@ for s in sessions:
 ### Find Data by Brain Region
 
 ```python
-from spyglass.common import ElectrodeGroup, BrainRegion
-from spyglass.lfp import LFPOutput
+from spyglass.common import BrainRegion, Electrode
+from spyglass.lfp import LFPElectrodeGroup, LFPOutput
 
-groups = (ElectrodeGroup & (BrainRegion & {'region_name': 'CA1'})).fetch('KEY')
+# LFPOutput.LFPV1 is keyed by `lfp_electrode_group_name`, not raw
+# `electrode_group_name`. Resolve through LFPElectrodeGroup.LFPElectrode
+# before restricting the merge table.
+lfp_electrodes = (
+    LFPElectrodeGroup.LFPElectrode
+    & (Electrode & (BrainRegion & {'region_name': 'CA1'}))
+).fetch("KEY", as_dict=True)
 
-for g in groups:
-    lfp = LFPOutput.merge_restrict(g)
+seen = set()
+for row in lfp_electrodes:
+    lfp_key = {
+        "nwb_file_name": row["nwb_file_name"],
+        "lfp_electrode_group_name": row["lfp_electrode_group_name"],
+    }
+    ident = tuple(lfp_key.items())
+    if ident in seen:
+        continue
+    seen.add(ident)
+    lfp = LFPOutput.merge_restrict(lfp_key)
     if len(lfp):
-        print(f"Found LFP for: {g}")
+        print(f"Found LFP for: {lfp_key}")
 ```
 
 ### Navigate Upstream/Downstream
 
 ```python
-# All position results for a session
+# Exploratory graph search. For copyable merge-table code, prefer
+# PositionOutput.merge_restrict({"nwb_file_name": nwb_file}).
 PositionOutput() << f"nwb_file_name = '{nwb_file}'"
 
 # Find sessions with specific parameters


### PR DESCRIPTION
## Summary

Batch B narrow first pass of the [reference-key-hygiene plan](docs/plans/reference-key-hygiene-impl-plan.md). Builds on PR #22 (Batch A + early Batch B). Four content commits + one plan-status commit, all on the priority files the plan called out.

## Commits

1. **\`docs: clarify merge usage and fetch cardinality\`** (`096961d`) — eight-file cleanup pass over runnable code blocks: cardinality guards before \`fetch_nwb\`, \`assert\` → explicit \`if/raise ValueError\` (avoids \`python -O\` strip), sharpened merge-master silent-no-op wording, fixed \`LFPElectrodeGroup.LFPElectrode\` join key in \`workflows.md\` (the original used common-tables \`ElectrodeGroup\` keys against \`LFPOutput\` which silently no-op'd — \`LFPOutput.LFPV1\` is keyed by \`lfp_electrode_group_name\`, not \`electrode_group_name\`), renamed shadowing \`ElectrodeGroup\` part class in \`custom_pipeline_authoring.md\`.

2. **\`Prefer code_graph/db_graph scripts for facts\`** (`068fb53`) — promote the bundled CLIs as the LLM-facing fact-check authority. Source-declared facts → \`code_graph.py describe / path / find-method\`; runtime DB facts → \`db_graph.py describe / path / find-instance\`. In-session DataJoint API kept as explicit fallback. Touches common_mistakes, common_tables, datajoint_api, spyglassmixin_methods, workflows.

3. **\`Clarify script paths and merge discovery\`** (`de1edc4`) — SKILL.md note that bare \`code_graph.py\` / \`db_graph.py\` references mean \`python skills/spyglass/scripts/<name>\`. Restores the friendly-keys → merge_id discovery hint to datajoint_api.md Best Practice #2 (lost in commit 2, called out in review).

4. **\`Clarify Evidence Expectations in spyglass SKILL\`** (`12d099e`) — small SKILL.md polish to keep the new line under the word-cap.

5. **\`plan: mark Batches A + B complete\`** (`e091114`) — plan status update + Progress log + Remaining work section.

## Out of scope (deferred per the plan)

- **Batch C** — narrow validator additions (\`populate({...})\` field checker; singular/plural near-miss; regression fixtures).
- **Batch D** — evals that pin the patterns this PR fixes.
- **Batch E** — maintainer checklist (only if drift recurs after C/D).

## Test plan

- [x] \`./skills/spyglass/scripts/validate_all.sh --baseline-warnings 3\` — passes with 3 baseline warnings (unchanged from master).
- [x] \`ruff check .\` — clean.
- [x] All cited CLI subcommands verified against \`code_graph.py --help\` and \`db_graph.py --help\`.
- [x] \`workflows.md\` LFPElectrodeGroup join verified against \`lfp/lfp_electrode.py:22-26\` source.